### PR TITLE
Add basic wifi functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Creates a new Panda instance
 
 * `options` (*optional* object)
   * `selectDevice`: (*optional* `function(devices, callback)`) A user defined function for selecting which available device to use, parameters are an array of discovered devices and a callback function. The method can either return the desired device, return a promise, or use the callback function. There is no timeout for this method, so make sure it eventually does one of those three things. *This option does nothing in browser mode since webusb has it's own UI for selecting the device.*
+  * `wifi`: (*optional* `boolean`) Enables wifi mode, communicates with the panda device over an already established wifi connection with it. This option will throw errors if you enable it in browser mode.
 
 ### Methods
 #### `Panda.connect()` -> `Promise: string`

--- a/dump-can.js
+++ b/dump-can.js
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
 
+const cli = require('commander');
 const Panda = require('./lib').default;
 const wait = require('./src/delay');
 
+cli
+  .option('-w, --wifi', 'Connect to Panda over wifi instead of USB')
+  .parse(process.argv);
+
 var panda = new Panda({
-  selectDevice: selectDevice
+  selectDevice: selectDevice,
+  wifi: cli.wifi
 });
 
 panda.onMessage(function (msg) {

--- a/dump-can.js
+++ b/dump-can.js
@@ -3,9 +3,15 @@
 const cli = require('commander');
 const Panda = require('./lib').default;
 const wait = require('./src/delay');
+const package = require('./package');
 
 cli
+  .version(package.version)
+  .description('Dump data from connected Panda over either USB or wifi. Uses pandajs under the hood.')
   .option('-w, --wifi', 'Connect to Panda over wifi instead of USB')
+  .option('-a, --all', 'Print every message instead of just summaries (VERY spammy, one message per line JSON encoded)')
+  .option('-n, --no-health', 'Don\'t print startup/connection messages (useful with --all and output redirection)')
+  .option('-e, --no-errors', 'Don\'t print errors either')
   .parse(process.argv);
 
 var panda = new Panda({
@@ -14,20 +20,39 @@ var panda = new Panda({
 });
 
 panda.onMessage(function (msg) {
-  console.log('Message count:', msg.length);
-  console.log('First message CAN count:', msg[0].canMessages.length);
-  console.log('First CAN message:', msg[0].canMessages[0]);
+  if (cli.all) {
+    msg.forEach((m) => console.log(JSON.stringify(m, function(k, v) {
+      if (!k) {
+        return v;
+      }
+      if (k === 'data' && v.type === 'Buffer') {
+        return v.data;
+        // return '0x' + Buffer.from(v.data).toString('hex');
+      }
+      return v;
+    })));
+  } else {
+    console.log('Message count:', msg.length);
+    console.log('First message CAN count:', msg[0].canMessages.length);
+    console.log('First CAN message:', msg[0].canMessages[0]);
+  }
 });
+
 panda.onError(function (err) {
-  console.error('Error:', err);
-  process.exit(1);
+  if (cli.health) {
+    console.error('Error:', err);
+    process.exit(1);
+  }
 });
-panda.onConnect(function (data) {
-  console.log('Connected:', data);
-});
-panda.onDisconnect(function (data) {
-  console.log('Disconnected:', data);
-});
+
+if (cli.health) {
+  panda.onConnect(function (data) {
+    console.log('Connected:', data);
+  });
+  panda.onDisconnect(function (data) {
+    console.log('Disconnected:', data);
+  });
+}
 
 connectAndRun();
 
@@ -38,10 +63,12 @@ function selectDevice (devices, cb) {
 
 async function connectAndRun () {
   await panda.connect();
-  var health = await panda.health();
-  console.log(health);
-  console.log('Connect finished, waiting then reading all messages...');
-  await wait(1000);
-  console.log('Start reading...');
+  if (cli.health) {
+    var health = await panda.health();
+    console.log(health);
+    console.log('Connect finished, waiting then reading all messages...');
+    await wait(1000);
+    console.log('Start reading...');
+  }
   panda.unpause();
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ap": "^0.2.0",
     "babel-runtime": "^6.26.0",
     "can-message": "^0.1.0",
+    "commander": "^2.15.1",
     "is-browser": "^2.0.1",
     "is-node": "^1.0.2",
     "is-promise": "^2.1.0",

--- a/src/impl/browser.js
+++ b/src/impl/browser.js
@@ -31,9 +31,7 @@ export default class Panda {
     await this.device.selectConfiguration(1);
     await this.device.claimInterface(0);
 
-    ConnectEvent.broadcast(this, this.device.serialNumber);
-
-    return this.device.serialNumber;
+    return true;
   }
 
   async disconnect() {

--- a/src/impl/mock.js
+++ b/src/impl/mock.js
@@ -15,9 +15,25 @@ export default class MockPanda {
     this.onDisconnect = partial(DisconnectEvent.listen, this);
   }
 
+  async vendorRequest (params, length) {
+    switch (params.request) {
+      case 0xd2:
+        return {
+          data: Buffer.from('0x6c2f0000b20f00000000000000'),
+          status: 'ok'
+        };
+      case 0xd0:
+        return {
+          data: Buffer.from('0x626134333533373534333663326136646b347a6776366c527744ffff6fe25de5'),
+          status: 'ok'
+        };
+      default:
+        console.error('UNMOCKED API CALL MADE', params.request);
+    }
+  }
+
   async connect() {
     await wait(100);
-    ConnectEvent.broadcast(this, '123345123');
     return '123345123'
   }
 

--- a/src/impl/node.js
+++ b/src/impl/node.js
@@ -75,10 +75,7 @@ export default class Panda {
     await this.setConfiguration(1);
     await this.device.interface(0).claim();
 
-    var serialNumber = await this.getStringDescriptor(this.device.deviceDescriptor.iSerialNumber);
-    ConnectEvent.broadcast(this, serialNumber);
-
-    return serialNumber;
+    return true;
   }
 
   async disconnect() {

--- a/src/impl/wifi.js
+++ b/src/impl/wifi.js
@@ -1,0 +1,178 @@
+import USB from 'usb';
+import { packCAN, unpackCAN } from 'can-message';
+import Event from 'weakmap-event';
+import { partial } from 'ap';
+import wait from '../delay';
+import isPromise from 'is-promise';
+import net from 'net';
+import dgram from 'dgram';
+
+const PANDA_MESSAGE_ENDPOINT_NUMBER = 1;
+const PANDA_HOST = '192.168.0.10';
+const PANDA_TCP_PORT = 1337;
+const PANDA_UDP_PORT = 1338;
+
+const REQUEST_OUT = 64;
+const REQUEST_IN = 192;
+
+const ErrorEvent = Event();
+const ConnectEvent = Event();
+const DisconnectEvent = Event();
+const DataEvent = Event();
+const MessageEvent = Event();
+
+export default class Panda {
+  constructor(options) {
+    this.device = null;
+    this.ignoreLengths = {};
+
+    this.onError = partial(ErrorEvent.listen, this);
+    this.onConnect = partial(ConnectEvent.listen, this);
+    this.onDisconnect = partial(DisconnectEvent.listen, this);
+    this.handleData = this.handleData.bind(this);
+  }
+  async connectToTCP() {
+    return new Promise((resolve, reject) => {
+      var fail = (err) => {
+        this.socket = null;
+        ErrorEvent.broadcast(this, err);
+        reject(err);
+      }
+      var succeed = () => {
+        this.socket.off('close', fail);
+        this.socket.off('error', fail);
+        resolve();
+      }
+
+      this.socket = net.connect(PANDA_TCP_PORT, PANDA_HOST);
+      this.socket.on('connect', resolve);
+      this.socket.on('close', fail);
+      this.socket.on('error', fail);
+    });
+  }
+  async connect() {
+    await this.connectToTCP();
+
+    this.socket.on('data', this.handleData);
+    this.socket.on('close', partial(DisconnectEvent.broadcast, this));
+    this.socket.on('error', partial(ErrorEvent.broadcast, this));
+
+    // var serialNumber = await this.getStringDescriptor(this.device.deviceDescriptor.iSerialNumber);
+    // ConnectEvent.broadcast(this, serialNumber);
+
+    return 'wifi';
+  }
+
+  async disconnect() {
+    if (!this.socket) {
+      return false;
+    }
+    await this.socket.close();
+    this.socket = null;
+
+    return true;
+  }
+
+  async vendorRequest(data, length) {
+    var data = await this.controlRead(REQUEST_OUT, data.request, data.value, data.index, length);
+    return {
+      data: Buffer.from(data),
+      status: "ok" // hack, find out when it's actually ok
+    };
+  }
+
+  // not used anymore, but is nice for reference
+  async nextFakeMessage() {
+    await wait(10);
+
+    return packCAN({
+      address: 0,
+      busTime: ~~(Math.random() * 65000),
+      data: ''.padEnd(16, '0'),
+      bus: 0
+    });
+  }
+
+  async controlRead(requestType, request, value, index, length) {
+    if (!this.ignoreLengths[length]) {
+      this.ignoreLengths[length] = 0;
+    }
+    this.ignoreLengths[length]++;
+
+    const buf = Buffer.alloc(12);
+    buf.writeUInt16LE(0, 0);
+    buf.writeUInt16LE(0, 2);
+    buf.writeUInt8(requestType, 4);
+    buf.writeUInt8(request, 5);
+    buf.writeUInt16LE(value, 6);
+    buf.writeUInt16LE(index, 8);
+    buf.writeUInt16LE(length, 10);
+
+    this.socket.write(buf);
+
+    return this.nextIncomingData();
+  }
+
+  async nextIncomingData() {
+    return new Promise((resolve, reject) => {
+      once(partial(DataEvent.listen, this), resolve);
+    });
+  }
+
+  async nextIncomingMessage() {
+    return new Promise((resolve, reject) => {
+      once(partial(MessageEvent.listen, this), resolve);
+    });
+  }
+
+  async nextMessage() {
+    var result = null;
+    var attempts = 0;
+
+    while (result === null) {
+      try {
+        return await this.bulkRead(1);
+      } catch (err) {
+        console.warn('can_recv failed, retrying');
+        attempts = Math.min(++attempts, 10);
+        await wait(attempts * 100);
+      }
+    }
+  }
+
+  async handleData(buf) {
+    const length = buf.readUInt32LE(0);
+    const data = buf.slice(4, 4 + length);
+    if (this.ignoreLengths[length]) {
+      this.ignoreLengths[length]--;
+      if (this.ignoreLengths[length] === 0) {
+        delete this.ignoreLengths[length];
+      }
+      DataEvent.broadcast(this, data);
+    } else {
+      MessageEvent.broadcast(this, data);
+    }
+  }
+
+  async bulkRead(endpoint: Number, timeoutMillis: Number = 0) {
+      const promise = this.nextIncomingMessage();
+
+      const buf = Buffer.alloc(4);
+      buf.writeUInt16LE(endpoint, 0);
+      buf.writeUInt16LE(0, 2);
+      this.socket.write(buf);
+
+      return promise;
+  }
+}
+
+function once (event, handler) {
+  var unlisten = event(onceHandler);
+
+  return unlisten;
+
+  function onceHandler() {
+    unlisten();
+    handler.apply(this, arguments);
+  }
+}

--- a/src/impl/wifi.js
+++ b/src/impl/wifi.js
@@ -58,10 +58,7 @@ export default class Panda {
     this.socket.on('close', partial(DisconnectEvent.broadcast, this));
     this.socket.on('error', this.handleError);
 
-    // var serialNumber = await this.getStringDescriptor(this.device.deviceDescriptor.iSerialNumber);
-    // ConnectEvent.broadcast(this, serialNumber);
-
-    return 'wifi';
+    return true;
   }
 
   async disconnect() {

--- a/src/index.js
+++ b/src/index.js
@@ -98,8 +98,8 @@ export default class Panda {
       let result = await this.device.vendorRequest(controlParams, 13);
       let buf = result.data;
 
-      let voltage = buf.readUInt32LE(0);
-      let current = buf.readUInt32LE(4);
+      let voltage = buf.readUInt32LE(0) / 1000;
+      let current = buf.readUInt32LE(4) / 1000;
       let isStarted = buf.readInt8(8) === 1;
       let controlsAreAllowed = buf.readInt8(9) === 1;
       let isGasInterceptorDetector = buf.readInt8(10) === 1;

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,13 @@ export default class Panda {
     if (this.isConnected()) {
       return this.connected;
     }
-    return this.device.connect();
+    await this.device.connect();
+
+    var serialNumber = await this.serialNumber();
+    this.connectHandler(serialNumber);
+    ConnectEvent.broadcast(this, serialNumber);
+
+    return serialNumber;
   }
   async disconnect() {
     if (!this.isConnected()) {
@@ -117,6 +123,25 @@ export default class Panda {
       };
     } catch (err) {
       ErrorEvent.broadcast(this, { event: 'Panda.health failed', error: err });
+    }
+  }
+
+  async serialNumber() {
+    const controlParams = {
+      request: 0xd0,
+      value: 0,
+      index: 0
+    };
+    try {
+      let result = await this.device.vendorRequest(controlParams, 32);
+      let buf = result.data;
+      let serial = buf.slice(0, 0x10); // serial is the wifi style serial
+      let serial2 = buf.slice(0x10, 0x1a);
+      let hashSig = buf.slice(0x1c);
+
+      return serial.toString();
+    } catch (err) {
+      ErrorEvent.broadcast(this, { event: 'Panda.serialNumber failed', error: err });
     }
   }
 

--- a/src/panda-usb.js
+++ b/src/panda-usb.js
@@ -1,8 +1,15 @@
 
 export default function PandaUSB (options) {
   if (require('is-browser')) {
+    if (options.wifi) {
+      throw new Error('You cannot use wifi mode in the browser.');
+    }
     let PandaWebUSB = require('./impl/browser').default;
     return new PandaWebUSB(options, navigator.usb);
+  }
+  if (options.wifi) {
+    let PandaWifi = require('./impl/wifi').default;
+    return new PandaWifi(options);
   }
   // check for test before node since tests always run in node
   if (isTestEnv()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,6 +840,10 @@ commander@^2.11.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
 
+commander@^2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
This allows you to pass in `wifi: true` as an option to the constructor to connect to the Panda device over wifi instead of USB. This will work in node and react-native environments but will throw an error in browser since the underlying network libraries aren't available.

This requires you already be connected to the panda device's wifi. A wrapper library for react-native will be created in the future to facilitate connecting automatically.

Also added `-w` and `--wifi` to `dump-can` so that you can use the CLI tool over wifi (which is also how I tested it)

Could use better connection/error handling, currently timed out requests will hang forever.