### PR TITLE
Add GitHub Actions workflow for test/build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install
+        run: |
+          yarn install
+          yarn add usb
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Build and test pandajs
+
+on: [push, pull_request]
+
+jobs:
+  build_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install
+      - run: yarn build
+      - run: yarn test


### PR DESCRIPTION
- installs dependencies
  - cache node_modules
  - install `usb` package on the runner so that the node tests can run
- build
- run tests