### PR TITLE
ci: yarn install ignore scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
             ${{ runner.os }}-yarn-
       - if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: |
-          yarn install
-          yarn add usb
+          yarn install --ignore-scripts
+          yarn add --ignore-scripts usb
       - run: yarn build
       - run: yarn test


### PR DESCRIPTION
This should stop CI from running `npm run build` three times (since there is the `prepare` script running it all of the time...)